### PR TITLE
New sent dep endpoint tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ ENV/
 frontend/node_modules
 .DS_Store
 .venv
+
+.idea/

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/spacy-api-docker.iml" filepath="$PROJECT_DIR$/.idea/spacy-api-docker.iml" />
-    </modules>
-  </component>
-</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
 install:
   - travis_wait 30 docker build -t jgontrum/spacyapi:base_v2 .
   - travis_wait 30 docker build -t jgontrum/spacyapi:en_v2 -f docker/en/Dockerfile .
+  - travis_wait 30 docker build -t jgontrum/spacyapi:en_v2_lg -f docker/en/Dockerfile.lg .
+  - travis_wait 30 docker build -t jgontrum/spacyapi:en_v2_md -f docker/en/Dockerfile.md .
   - travis_wait 30 docker build -t jgontrum/spacyapi:de_v2 -f docker/de/Dockerfile .
   - travis_wait 30 docker build -t jgontrum/spacyapi:es_v2 -f docker/es/Dockerfile .
   - travis_wait 30 docker build -t jgontrum/spacyapi:fr_v2 -f docker/fr/Dockerfile .
@@ -23,6 +25,8 @@ install:
 after_success:
   - docker push jgontrum/spacyapi:base_v2
   - docker push jgontrum/spacyapi:en_v2
+  - docker push jgontrum/spacyapi:en_v2_lg
+  - docker push jgontrum/spacyapi:en_v2_md
   - docker push jgontrum/spacyapi:de_v2
   - docker push jgontrum/spacyapi:es_v2
   - docker push jgontrum/spacyapi:fr_v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     apt-get -q clean -y && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # Install node for the frontend
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt-get install -y nodejs &&\
   apt-get -q clean -y && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,250 @@ Example response:
 ["In 2012 I was a mediocre developer.", "But today I am at least a bit better."]
 ```
 
+---
+
+### `POST` `/sents_dep/`
+
+Combination of `/sents/` and `/dep/`, returns sentences and dependency parses
+
+Example request:
+
+```json
+{
+  "text": "In 2012 I was a mediocre developer. But today I am at least a bit better.",
+  "model": "en"
+}
+```
+
+| Name    | Type   | Description                                           |
+| ------- | ------ | ----------------------------------------------------- |
+| `text`  | string | text to be parsed                                     |
+| `model` | string | identifier string for a model installed on the server |
+
+Example request using the Python [Requests library](http://docs.python-requests.org/en/master/):
+
+```python
+import json
+import requests
+
+url = "http://localhost:8000/sents_dep"
+message_text = "In 2012 I was a mediocre developer. But today I am at least a bit better."
+headers = {'content-type': 'application/json'}
+d = {'text': message_text, 'model': 'en'}
+
+response = requests.post(url, data=json.dumps(d), headers=headers)
+r = response.json()
+```
+
+Example response:
+
+```json
+[
+  {
+    "sentence": "In 2012 I was a mediocre developer.",
+    "dep_parse": {
+      "arcs": [
+        {
+          "dir": "left",
+          "end": 3,
+          "label": "prep",
+          "start": 0,
+          "text": "In"
+        },
+        {
+          "dir": "right",
+          "end": 1,
+          "label": "pobj",
+          "start": 0,
+          "text": "2012"
+        },
+        {
+          "dir": "left",
+          "end": 3,
+          "label": "nsubj",
+          "start": 2,
+          "text": "I"
+        },
+        {
+          "dir": "left",
+          "end": 6,
+          "label": "det",
+          "start": 4,
+          "text": "a"
+        },
+        {
+          "dir": "left",
+          "end": 6,
+          "label": "amod",
+          "start": 5,
+          "text": "mediocre"
+        },
+        {
+          "dir": "right",
+          "end": 6,
+          "label": "attr",
+          "start": 3,
+          "text": "developer"
+        },
+        {
+          "dir": "right",
+          "end": 7,
+          "label": "punct",
+          "start": 3,
+          "text": "."
+        }
+      ],
+      "words": [
+        {
+          "tag": "IN",
+          "text": "In"
+        },
+        {
+          "tag": "CD",
+          "text": "2012"
+        },
+        {
+          "tag": "PRP",
+          "text": "I"
+        },
+        {
+          "tag": "VBD",
+          "text": "was"
+        },
+        {
+          "tag": "DT",
+          "text": "a"
+        },
+        {
+          "tag": "JJ",
+          "text": "mediocre"
+        },
+        {
+          "tag": "NN",
+          "text": "developer"
+        },
+        {
+          "tag": ".",
+          "text": "."
+        }
+      ]
+    }
+  },
+  {
+    "sentence": "But today I am at least a bit better.",
+    "dep_parse": {
+      "arcs": [
+        {
+          "dir": "left",
+          "end": 11,
+          "label": "cc",
+          "start": 8,
+          "text": "But"
+        },
+        {
+          "dir": "left",
+          "end": 11,
+          "label": "npadvmod",
+          "start": 9,
+          "text": "today"
+        },
+        {
+          "dir": "left",
+          "end": 11,
+          "label": "nsubj",
+          "start": 10,
+          "text": "I"
+        },
+        {
+          "dir": "left",
+          "end": 13,
+          "label": "advmod",
+          "start": 12,
+          "text": "at"
+        },
+        {
+          "dir": "left",
+          "end": 15,
+          "label": "advmod",
+          "start": 13,
+          "text": "least"
+        },
+        {
+          "dir": "left",
+          "end": 15,
+          "label": "det",
+          "start": 14,
+          "text": "a"
+        },
+        {
+          "dir": "left",
+          "end": 16,
+          "label": "npadvmod",
+          "start": 15,
+          "text": "bit"
+        },
+        {
+          "dir": "right",
+          "end": 16,
+          "label": "acomp",
+          "start": 11,
+          "text": "better"
+        },
+        {
+          "dir": "right",
+          "end": 17,
+          "label": "punct",
+          "start": 11,
+          "text": "."
+        }
+      ],
+      "words": [
+        {
+          "tag": "CC",
+          "text": "But"
+        },
+        {
+          "tag": "NN",
+          "text": "today"
+        },
+        {
+          "tag": "PRP",
+          "text": "I"
+        },
+        {
+          "tag": "VBP",
+          "text": "am"
+        },
+        {
+          "tag": "IN",
+          "text": "at"
+        },
+        {
+          "tag": "JJS",
+          "text": "least"
+        },
+        {
+          "tag": "DT",
+          "text": "a"
+        },
+        {
+          "tag": "NN",
+          "text": "bit"
+        },
+        {
+          "tag": "RBR",
+          "text": "better"
+        },
+        {
+          "tag": ".",
+          "text": "."
+        }
+      ]
+    }
+  }
+]
+```
+
 ### `GET` `/models`
 
 List the names of models installed on the server.

--- a/displacy_service/parse.py
+++ b/displacy_service/parse.py
@@ -1,35 +1,5 @@
 from spacy.symbols import ORTH
 
-contractions = [[{ORTH: "you've"}],	[{ORTH: "you're"}],	[{ORTH: "you'll"}],	[{ORTH: "you'd"}],
-                [{ORTH: "y'all'd've"}],	[{ORTH: "y'all"}],	[{ORTH: "wouldn't"}], [{ORTH: "would've"}],
-                [{ORTH: "won't"}], [{ORTH: "why's"}],	[{ORTH: "why're"}],	[{ORTH: "why'd"}], [{ORTH: "whom'st'd've"}],
-                [{ORTH: "whom'st"}], [{ORTH: "who've"}], [{ORTH: "who's"}], [{ORTH: "who're"}], [{ORTH: "who'll"}],
-                [{ORTH: "who'd've"}], [{ORTH: "who'd"}], [{ORTH: "which's"}], [{ORTH: "where've"}],
-                [{ORTH: "where's"}], [{ORTH: "where're"}], [{ORTH: "where'd"}], [{ORTH: "when's"}],
-                [{ORTH: "what've"}], [{ORTH: "what's"}], [{ORTH: "what're"}], [{ORTH: "what'll"}],
-                [{ORTH: "what'd"}], [{ORTH: "weren't"}], [{ORTH: "we've"}],	[{ORTH: "we're"}],	[{ORTH: "we'll"}],
-                [{ORTH: "we'd've"}],[{ORTH: "we'd"}], [{ORTH: "wasn't"}], [{ORTH: "those're"}], [{ORTH: "this's"}],
-                [{ORTH: "they've"}], [{ORTH: "they're"}], [{ORTH: "they'll"}], [{ORTH: "they'd"}],
-                [{ORTH: "these're"}], [{ORTH: "there's"}], [{ORTH: "there're"}], [{ORTH: "there'll"}],
-                [{ORTH: "there'd"}], [{ORTH: "that's"}], [{ORTH: "that're"}], [{ORTH: "that'll"}],
-                [{ORTH: "that'd"}], [{ORTH: "something's"}], [{ORTH: "someone's"}], [{ORTH: "somebody's"}],
-                [{ORTH: "so're"}], [{ORTH: "shouldn't've"}], [{ORTH: "shouldn't"}],	[{ORTH: "should've"}],
-                [{ORTH: "she's"}], [{ORTH: "she'll"}], [{ORTH: "she'd"}], [{ORTH: "shan't"}], [{ORTH: "shalln't"}],
-                [{ORTH: "oughtn't"}], [{ORTH: "ol'"}], [{ORTH: "o'er"}], [{ORTH: "o'clock"}], [{ORTH: "noun's"}],
-                [{ORTH: "needn't"}], [{ORTH: "ne'er"}], [{ORTH: "mustn't've"}], [{ORTH: "mustn't"}],
-                [{ORTH: "must've"}], [{ORTH: "mightn't"}], [{ORTH: "might've"}], [{ORTH: "mayn't"}],
-                [{ORTH: "may've"}], [{ORTH: "ma'am"}], [{ORTH: "let's"}], [{ORTH: "it's"}], [{ORTH: "it'll"}],
-                [{ORTH: "it'd"}], [{ORTH: "isn't"}], [{ORTH: "i've"}], [{ORTH: "i'm'o"}], [{ORTH: "i'm'a"}],
-                [{ORTH: "i'm"}], [{ORTH: "i'll"}], [{ORTH: "i'd"}], [{ORTH: "howdy"}], [{ORTH: "how's"}],
-                [{ORTH: "how're"}], [{ORTH: "how'll"}], [{ORTH: "how'd"}], [{ORTH: "he've"}], [{ORTH: "he's"}],
-                [{ORTH: "he'll"}], [{ORTH: "he'd"}], [{ORTH: "haven't"}], [{ORTH: "hasn't"}], [{ORTH: "hadn't"}],
-                [{ORTH: "gotta"}], [{ORTH: "gonna"}], [{ORTH: "gon't"}], [{ORTH: "giv’n"}],
-                [{ORTH: "gimme"}], [{ORTH: "finna"}], [{ORTH: "everyone's"}], [{ORTH: "e'er"}], [{ORTH: "don't"}],
-                [{ORTH: "doesn't"}], [{ORTH: "didn't"}], [{ORTH: "dasn't"}], [{ORTH: "daresn't"}],
-                [{ORTH: "daren't"}], [{ORTH: "couldn't've"}], [{ORTH: "couldn't"}], [{ORTH: "could've"}],
-                [{ORTH: "can't"}], [{ORTH: " cain't"}], [{ORTH: "aren't"}], [{ORTH: "amn't"}], [{ORTH: "ain't"}],
-                [{ORTH: "'twas	"}], [{ORTH: "'tis"}], [{ORTH: "'s"}], [{ORTH: "'cause"}]]
-
 
 class Parse(object):
     def __init__(self, nlp, text, collapse_punctuation, collapse_phrases):
@@ -106,11 +76,11 @@ class Sentences(object):
 
 
 class SentencesDependencies(object):
-    def __init__(self, nlp, text, collapse_punctuation, collapse_phrases, collapse_contractions):
+    def __init__(self, nlp, text, collapse_punctuation, collapse_phrases, special_cases):
 
-        if collapse_contractions:
-            for contraction in contractions:
-                nlp.tokenizer.add_special_case(contraction[0][ORTH], contraction)
+        if special_cases:
+            for special_case in special_cases:
+                nlp.tokenizer.add_special_case(special_case, [{ORTH: special_case}])
 
         self.doc = nlp(text)
 
@@ -165,4 +135,3 @@ class SentencesDependencies(object):
                           'dep_parse': {'words': words,
                                         'arcs': arcs}})
         return sents
-

--- a/displacy_service/server.py
+++ b/displacy_service/server.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from pathlib import Path
 import falcon
 import spacy
 import json
@@ -186,7 +185,7 @@ class SentsDepResources(object):
         model_name = json_data.get('model', 'en')
         collapse_punctuation = json_data.get('collapse_punctuation', False)
         collapse_phrases = json_data.get('collapse_phrases', False)
-        collapse_contractions = json_data.get('collapse_contractions', False)
+        special_cases = json_data.get('special_cases', [])
 
         try:
             model = get_model(model_name)
@@ -194,7 +193,7 @@ class SentsDepResources(object):
                                               text,
                                               collapse_punctuation=collapse_punctuation,
                                               collapse_phrases=collapse_phrases,
-                                              collapse_contractions=collapse_contractions)
+                                              special_cases=special_cases)
 
             resp.body = json.dumps(sentences.to_json(),
                                    sort_keys=True,

--- a/displacy_service_tests/test_server.py
+++ b/displacy_service_tests/test_server.py
@@ -50,47 +50,18 @@ def test_sents_dep():
     sentence_parse = test_api.simulate_post(
         path='/sents_dep',
         body='''{"text": "This a test that should split into sentences!
-        This is the second. Is this the third?", "model": "en", 
+        This is the second. Is this the third?", "model": "en",
         "collapse_punctuation": false, "collapse_phrases": false}'''
     )
-    assert sentence_parse == [{'sentence': 'This a test that should split into sentences!',
-                               'dep_parse':
-                                   {'words': [{'text': 'This', 'tag': 'DT'},
-                                              {'text': 'a', 'tag': 'DT'},
-                                              {'text': 'test', 'tag': 'NN'},
-                                              {'text': 'that', 'tag': 'WDT'},
-                                              {'text': 'should', 'tag': 'MD'},
-                                              {'text': 'split', 'tag': 'VB'},
-                                              {'text': 'into', 'tag': 'IN'},
-                                              {'text': 'sentences', 'tag': 'NNS'},
-                                              {'text': '!', 'tag': '.'}],
-                                    'arcs': [{'start': 0, 'end': 2, 'label': 'det', 'text': 'This', 'dir': 'left'},
-                                             {'start': 1, 'end': 2, 'label': 'det', 'text': 'a', 'dir': 'left'},
-                                             {'start': 3, 'end': 5, 'label': 'nsubj', 'text': 'that', 'dir': 'left'},
-                                             {'start': 4, 'end': 5, 'label': 'aux', 'text': 'should', 'dir': 'left'},
-                                             {'start': 2, 'end': 5, 'label': 'relcl', 'text': 'split', 'dir': 'right'},
-                                             {'start': 5, 'end': 6, 'label': 'prep', 'text': 'into', 'dir': 'right'},
-                                             {'start': 6, 'end': 7, 'label': 'pobj', 'text': 'sentences', 'dir': 'right'},
-                                             {'start': 2, 'end': 8, 'label': 'punct', 'text': '!', 'dir': 'right'}]}},
-                              {'sentence': 'This is the second.',
-                               'dep_parse': {'words':
-                                                 [{'text': 'This', 'tag': 'DT'},
-                                                  {'text': 'is', 'tag': 'VBZ'},
-                                                  {'text': 'the', 'tag': 'DT'},
-                                                  {'text': 'second', 'tag': 'JJ'},
-                                                  {'text': '.', 'tag': '.'}],
-                                             'arcs': [{'start': 0, 'end': 1, 'label': 'nsubj', 'text': 'This', 'dir': 'left'},
-                                                      {'start': 2, 'end': 3, 'label': 'det', 'text': 'the', 'dir': 'left'},
-                                                      {'start': 1, 'end': 3, 'label': 'attr', 'text': 'second', 'dir': 'right'},
-                                                      {'start': 1, 'end': 4, 'label': 'punct', 'text': '.', 'dir': 'right'}]}},
-                              {'sentence': 'Is this the third?',
-                               'dep_parse': {'words':
-                                                 [{'text': 'Is', 'tag': 'VBZ'},
-                                                  {'text': 'this', 'tag': 'DT'},
-                                                  {'text': 'the', 'tag': 'DT'},
-                                                  {'text': 'third', 'tag': 'JJ'},
-                                                  {'text': '?', 'tag': '.'}],
-                                             'arcs': [{'start': 0, 'end': 1, 'label': 'nsubj', 'text': 'this', 'dir': 'right'},
-                                                      {'start': 2, 'end': 3, 'label': 'det', 'text': 'the', 'dir': 'left'},
-                                                      {'start': 0, 'end': 3, 'label': 'attr', 'text': 'third', 'dir': 'right'},
-                                                      {'start': 0, 'end': 4, 'label': 'punct', 'text': '?', 'dir': 'right'}]}}]
+    sentences = [sp["sentence"] for sp in sentence_parse]
+    assert sentences == [
+        "This a test that should split into sentences!",
+        "This is the second.",
+        "Is this the third?",
+    ]
+    words = [[w["text"] for w in sp["dep_parse"]["words"]] for sp in sentence_parse]
+    assert words == [
+        ["This", "a", "test", "that", "should", "split", "into", "sentences", "!"],
+        ["This", "is", "the", "second", "."],
+        ["Is", "this", "the", "third", "?"],
+    ]

--- a/docker/en/Dockerfile.lg
+++ b/docker/en/Dockerfile.lg
@@ -1,0 +1,4 @@
+FROM jgontrum/spacyapi:base_v2
+
+ENV languages "en_core_web_lg"
+RUN cd /app && env/bin/download_models

--- a/docker/en/Dockerfile.md
+++ b/docker/en/Dockerfile.md
@@ -1,0 +1,4 @@
+FROM jgontrum/spacyapi:base_v2
+
+ENV languages "en_core_web_md"
+RUN cd /app && env/bin/download_models

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy
+spacy==2.2.*
 falcon==2.0.0
 pytest
 requests==2.21.0


### PR DESCRIPTION
- Merged in upstream changes (spaCy 2.2, medium and large models)
- Tweaked the test assertion to follow existing conventions a bit more
- Fixed `.gitignore`, removed `.idea/` files

Still have an existing question about the contractions stuff... I'm thinking we should make it a bit more generic and language-agnostic, like maybe allowing `/sents_dep/` to take in a list of tokenizer special cases which it then applies. I'm also curious about the mechanic of adding the special cases in that way... Will we be repeatedly adding those special cases to the model every time the endpoint is called? Or is spaCy smart enough to see it already has that special case and not add an additional equivalent special case? @mjfox3 let me know what you think